### PR TITLE
Fix cache issue with referrer

### DIFF
--- a/src/ChunkFieldValue.jsx
+++ b/src/ChunkFieldValue.jsx
@@ -3,7 +3,7 @@ import React, { useContext } from "react";
 import { renderChunk } from "./utilities";
 import { ChunkCollectionContext } from "./ChunkCollectionContext";
 
-export function ChunkFieldValue({ children, identifier, transformation, ...props }) {
+export function ChunkFieldValue({ children, identifier, transformation, contentOnly = false, ...props }) {
   const chunk = useContext(ChunkCollectionContext);
 
   if (!chunk) {
@@ -33,7 +33,13 @@ export function ChunkFieldValue({ children, identifier, transformation, ...props
   if (chunk && fieldChunk) {
     props = {...props, "data-parent-identifier": chunk.identifier, 'data-custom-field-identifier': fieldChunk.custom_field_identifier }
   }
-  return renderChunk(dummyFieldChunk || fieldChunk, props);
+
+  if (contentOnly) {
+    return fieldChunk.content
+  } else {
+    return renderChunk(dummyFieldChunk || fieldChunk, props);
+  }
+  
 }
 
 export default ChunkFieldValue;

--- a/src/ChunkFieldValue.jsx
+++ b/src/ChunkFieldValue.jsx
@@ -3,7 +3,7 @@ import React, { useContext } from "react";
 import { renderChunk } from "./utilities";
 import { ChunkCollectionContext } from "./ChunkCollectionContext";
 
-export function ChunkFieldValue({ children, identifier, transformation, contentOnly = false, ...props }) {
+export function ChunkFieldValue({ children, identifier, transformation, ...props }) {
   const chunk = useContext(ChunkCollectionContext);
 
   if (!chunk) {
@@ -34,12 +34,7 @@ export function ChunkFieldValue({ children, identifier, transformation, contentO
     props = {...props, "data-parent-identifier": chunk.identifier, 'data-custom-field-identifier': fieldChunk.custom_field_identifier }
   }
 
-  if (contentOnly) {
-    return fieldChunk.content
-  } else {
-    return renderChunk(dummyFieldChunk || fieldChunk, props);
-  }
-  
+  return renderChunk(dummyFieldChunk || fieldChunk, props);
 }
 
 export default ChunkFieldValue;

--- a/src/utilities/api.js
+++ b/src/utilities/api.js
@@ -4,8 +4,6 @@ export const api = axios.create({
   baseURL: "https://api2.editmode.com/",
   headers: {
     Accept: "application/json",
-  },
-  params: {
-    referrer: window.location.href,
-  },
+    "Editmode-Referrer": window.location.href,
+  }
 });


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>3.1.27-canary.49.ef39aeb.1</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install editmode-react@3.1.27-canary.49.ef39aeb.1
  # or 
  yarn add editmode-react@3.1.27-canary.49.ef39aeb.1
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
